### PR TITLE
ci: publish releases to the Homebrew tap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,3 +30,17 @@ jobs:
           files: "shig-${{matrix.os}}-${{matrix.arch}}${{matrix.extension}}"
           token: ${{ secrets.GITHUB_TOKEN }}
           overwrite: "true"
+
+  tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Update Homebrew Tap
+        uses: SierraSoftworks/actions-tap@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          aliases: major minor


### PR DESCRIPTION
Adds a fan-in job (needs build) that calls SierraSoftworks/actions-tap to update the shig Homebrew formula whenever a release is published, generating major and minor versioned aliases for the formula.